### PR TITLE
Purge getEffectValue as it is missleading, confusing and unreliable.

### DIFF
--- a/Champions/Blitzcrank/Q.cs
+++ b/Champions/Blitzcrank/Q.cs
@@ -38,7 +38,7 @@ namespace Blitzcrank
                 var range = to * 50;
                 var trueCoords = current + range;
 
-                ApiFunctionManager.DashToLocation(spell.Target, trueCoords.X, trueCoords.Y, spell.spellData.MissileSpeed, true);
+                ApiFunctionManager.DashToLocation(spell.Target, trueCoords.X, trueCoords.Y, spell.SpellData.MissileSpeed, true);
             }
 
             projectile.setToRemove();

--- a/Champions/Blitzcrank/Q.cs
+++ b/Champions/Blitzcrank/Q.cs
@@ -38,7 +38,7 @@ namespace Blitzcrank
                 var range = to * 50;
                 var trueCoords = current + range;
 
-                ApiFunctionManager.DashToLocation(spell.Target, trueCoords.X, trueCoords.Y, spell.ProjectileSpeed, true);
+                ApiFunctionManager.DashToLocation(spell.Target, trueCoords.X, trueCoords.Y, spell.spellData.MissileSpeed, true);
             }
 
             projectile.setToRemove();

--- a/Champions/Caitlyn/Q.cs
+++ b/Champions/Caitlyn/Q.cs
@@ -29,7 +29,6 @@ namespace Caitlyn
             var reduc = Math.Min(projectile.ObjectsHit.Count, 5);
             var baseDamage = new[] {20, 60, 100, 140, 180}[spell.Level - 1] + 1.3f * owner.GetStats().AttackDamage.Total;
             var damage = baseDamage * (1 - reduc / 10);
-            ApiFunctionManager.PrintChat($"getEffectValue: {spell.getEffectValue(0)}, baseDamage: {baseDamage}, damage: {damage}");
             owner.DealDamageTo(target, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
         }
         public void OnUpdate(double diff) {

--- a/Champions/Caitlyn/R.cs
+++ b/Champions/Caitlyn/R.cs
@@ -23,7 +23,8 @@ namespace Caitlyn
         public void ApplyEffects(Champion owner, Unit target, Spell spell, Projectile projectile) {
             if (target != null && !target.IsDead)
             {
-                var damage = spell.getEffectValue(0) + owner.GetStats().AttackDamage.Total * 2;
+                // 250/475/700
+                var damage = 250 + owner.GetStats().AttackDamage.Total * 2;
                 owner.DealDamageTo(target, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
             }
             projectile.setToRemove();


### PR DESCRIPTION
Get effect value relies on _tooltip_ variables that are stored in specific spell inibin.
Its hard to say which one is which as they might be subject to change beetween patches therefor using them is harder that raw numbers in spell script not to mention specfici SpellData inibin instance has to specified.
They are not indented to be used as source for spell damage, heal value etc. in the first place.
