### PR TITLE
Add app.config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 [Bb]in/
 [Oo]bj/
 
+# App config
+app.config
+
 #test VS2015
 GameServer.sln.ide/
 


### PR DESCRIPTION
app.config is autogenerated by Visual Studio, but we don't want it in the repo

No refs