### PR TITLE
Added Active Data, Updated Smite.

### DIFF
--- a/Buffs/YoumuusGhostblade/YoumuusGhostblade.cs
+++ b/Buffs/YoumuusGhostblade/YoumuusGhostblade.cs
@@ -1,7 +1,7 @@
-﻿using LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits.AI;
-using LeagueSandbox.GameServer.Logic.GameObjects.Spells;
-using LeagueSandbox.GameServer.Logic.GameObjects.Stats;
-using LeagueSandbox.GameServer.Logic.Scripting.CSharp;
+﻿using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+using LeagueSandbox.GameServer.GameObjects.Spells;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+using LeagueSandbox.GameServer.Scripting.CSharp;
 
 namespace YoumuusGhostblade
 {

--- a/Buffs/YoumuusGhostblade/YoumuusGhostblade.cs
+++ b/Buffs/YoumuusGhostblade/YoumuusGhostblade.cs
@@ -1,0 +1,30 @@
+﻿using LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits.AI;
+using LeagueSandbox.GameServer.Logic.GameObjects.Spells;
+using LeagueSandbox.GameServer.Logic.GameObjects.Stats;
+using LeagueSandbox.GameServer.Logic.Scripting.CSharp;
+
+namespace YoumuusGhostblade
+{
+    internal class YoumuusGhostblade : IBuffGameScript
+    {
+        private StatsModifier _statMod;
+
+        public void OnActivate(ObjAiBase unit, Spell ownerSpell)
+        {
+            _statMod = new StatsModifier();
+            _statMod.MoveSpeed.PercentBonus = 0.2f;
+            _statMod.AttackSpeed.PercentBonus = 0.4f;
+            unit.AddStatModifier(_statMod);
+        }
+
+        public void OnDeactivate(ObjAiBase unit)
+        {
+            unit.RemoveStatModifier(_statMod);
+        }
+
+        public void OnUpdate(double diff)
+        {
+
+        }
+    }
+}

--- a/Champions/Global/DeathfireGrasp.cs
+++ b/Champions/Global/DeathfireGrasp.cs
@@ -1,21 +1,24 @@
-using GameServerCore.Enums;
+﻿using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.API;
+using LeagueSandbox.GameServer.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
-using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
-using LeagueSandbox.GameServer.Scripting.CSharp;
+using LeagueSandbox.GameServer.GameObjects.Missiles;
+using GameServerCore.Enums;
 
 namespace Spells
 {
-    public class SummonerSmite : IGameScript
+    public class DeathfireGrasp : IGameScript
     {
         public void OnStartCasting(Champion owner, Spell spell, AttackableUnit target)
         {
-            ApiFunctionManager.AddParticleTarget(owner, "Global_SS_Smite.troy", target, 1);
-            var damage = new float[] {390, 410, 430, 450, 480, 510, 540, 570, 600, 640, 680, 420,
-                760, 800, 850, 900, 950, 1000}[owner.Stats.Level - 1];
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            spell.AddProjectileTarget("DeathfireGraspSpell",target);
+            var p = ApiFunctionManager.AddParticleTarget(owner, "deathFireGrasp_tar.troy", target);
+            ApiFunctionManager.CreateTimer(4.0f, () =>
+            {
+                ApiFunctionManager.RemoveParticle(p);
+            });
         }
 
         public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
@@ -24,6 +27,9 @@ namespace Spells
 
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
+            var damage = target.Stats.HealthPoints.Total * 0.15f;
+            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL, false);
+            projectile.SetToRemove();
         }
 
         public void OnUpdate(double diff)
@@ -39,4 +45,3 @@ namespace Spells
         }
     }
 }
-

--- a/Champions/Global/DeathfireGrasp.cs
+++ b/Champions/Global/DeathfireGrasp.cs
@@ -14,10 +14,12 @@ namespace Spells
         public void OnStartCasting(Champion owner, Spell spell, AttackableUnit target)
         {
             spell.AddProjectileTarget("DeathfireGraspSpell",target);
-            var p = ApiFunctionManager.AddParticleTarget(owner, "deathFireGrasp_tar.troy", target);
+            var p1 = ApiFunctionManager.AddParticleTarget(owner, "deathFireGrasp_tar.troy", target);
+            var p2 = ApiFunctionManager.AddParticleTarget(owner, "obj_DeathfireGrasp_debuff.troy", target);
             ApiFunctionManager.CreateTimer(4.0f, () =>
             {
-                ApiFunctionManager.RemoveParticle(p);
+                ApiFunctionManager.RemoveParticle(p1);
+                ApiFunctionManager.RemoveParticle(p2);
             });
         }
 

--- a/Champions/Global/YoumusBlade.cs
+++ b/Champions/Global/YoumusBlade.cs
@@ -1,4 +1,4 @@
-using GameServerCore.Enums;
+﻿using GameServerCore.Enums;
 using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
@@ -8,18 +8,20 @@ using LeagueSandbox.GameServer.Scripting.CSharp;
 
 namespace Spells
 {
-    public class SummonerSmite : IGameScript
+    public class YoumusBlade : IGameScript
     {
         public void OnStartCasting(Champion owner, Spell spell, AttackableUnit target)
         {
-            ApiFunctionManager.AddParticleTarget(owner, "Global_SS_Smite.troy", target, 1);
-            var damage = new float[] {390, 410, 430, 450, 480, 510, 540, 570, 600, 640, 680, 420,
-                760, 800, 850, 900, 950, 1000}[owner.Stats.Level - 1];
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SPELL, false);
         }
 
         public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
         {
+            var buff = owner.AddBuffGameScript("YoumuusGhostblade", "YoumuusGhostblade", spell, 6.0f);
+            var p = ApiFunctionManager.AddParticleTarget(owner, "spectral_fury_activate_speed.troy", owner, 2);
+            ApiFunctionManager.CreateTimer(6.0f, () =>
+            {
+                ApiFunctionManager.RemoveParticle(p);
+            });
         }
 
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
@@ -39,4 +41,3 @@ namespace Spells
         }
     }
 }
-

--- a/LeagueSandbox-Default.csproj
+++ b/LeagueSandbox-Default.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Champions\Akali\R.cs" />
     <Compile Include="Champions\Akali\W.cs" />
     <Compile Include="Champions\Annie\Q.cs" />
+    <Compile Include="Champions\Annie\W.cs" />
     <Compile Include="Champions\Blitzcrank\Q.cs" />
     <Compile Include="Champions\Blitzcrank\W.cs" />
     <Compile Include="Champions\Caitlyn\E.cs" />
@@ -74,6 +75,7 @@
     <Compile Include="Champions\Ezreal\Passive.cs" />
     <Compile Include="Champions\Gangplank\Q.cs" />
     <Compile Include="Champions\Garen\E.cs" />
+    <Compile Include="Champions\Global\DeathfireGrasp.cs" />
     <Compile Include="Champions\Global\SummonerDot.cs" />
     <Compile Include="Champions\Global\SummonerExhaust.cs" />
     <Compile Include="Champions\Global\SummonerFlash.cs" />
@@ -83,6 +85,7 @@
     <Compile Include="Champions\Global\SummonerMana.cs" />
     <Compile Include="Champions\Global\SummonerRevive.cs" />
     <Compile Include="Champions\Global\SummonerSmite.cs" />
+    <Compile Include="Champions\Global\YoumusBlade.cs" />
     <Compile Include="Champions\Graves\E.cs" />
     <Compile Include="Champions\Karthus\R.cs" />
     <Compile Include="Champions\Kassadin\Q.cs" />


### PR DESCRIPTION
updated Smite to properly scale from 390-1000 (based on level), rather than 370 + (20 per level) (which is 390 - 730, based on level). Additonally, I've added spell scripts for Deathfire Grasp and Youmuu's Ghostblade for testing Item Actives.