### PR TITLE
Summoner Heal update.

### DIFF
--- a/Buffs/HealCheck/HealCheck.cs
+++ b/Buffs/HealCheck/HealCheck.cs
@@ -1,0 +1,27 @@
+﻿using LeagueSandbox.GameServer.API;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+using LeagueSandbox.GameServer.GameObjects.Spells;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+
+namespace HealCheck
+{
+    internal class HealCheck : IBuffGameScript
+    {
+        private Buff _healBuff;
+
+        public void OnActivate(ObjAiBase unit, Spell ownerSpell)
+        {
+            _healBuff = ApiFunctionManager.AddBuffHudVisual("SummonerHealCheck", 35.0f, 1, unit);
+        }
+
+        public void OnDeactivate(ObjAiBase unit)
+        {
+            ApiFunctionManager.RemoveBuffHudVisual(_healBuff);
+        }
+
+        public void OnUpdate(double diff)
+        {
+
+        }
+    }
+}

--- a/Buffs/HealSpeed/HealSpeed.cs
+++ b/Buffs/HealSpeed/HealSpeed.cs
@@ -1,0 +1,33 @@
+﻿using LeagueSandbox.GameServer.API;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+using LeagueSandbox.GameServer.GameObjects.Spells;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+
+namespace HealSpeed
+{
+    internal class HealSpeed : IBuffGameScript
+    {
+        private StatsModifier _statMod;
+        private Buff _healBuff;
+
+        public void OnActivate(ObjAiBase unit, Spell ownerSpell)
+        {
+            _statMod = new StatsModifier();
+            _statMod.MoveSpeed.PercentBonus = 0.3f;
+            unit.AddStatModifier(_statMod);
+            _healBuff = ApiFunctionManager.AddBuffHudVisual("SummonerHeal", 1.0f, 1, unit);
+        }
+
+        public void OnDeactivate(ObjAiBase unit)
+        {
+            unit.RemoveStatModifier(_statMod);
+            ApiFunctionManager.RemoveBuffHudVisual(_healBuff);
+        }
+
+        public void OnUpdate(double diff)
+        {
+
+        }
+    }
+}

--- a/Champions/Global/SummonerHeal.cs
+++ b/Champions/Global/SummonerHeal.cs
@@ -22,8 +22,6 @@ namespace Spells
             Champion mostWoundedAlliedChampion = null;
             float lowestHealthPercentage = 100;
             float maxHealth;
-            float newHealth;
-            float healthGain;
             foreach(var value in units) {
                 if (owner.Team == value.Team)
                 {
@@ -39,37 +37,29 @@ namespace Spells
 
             if (mostWoundedAlliedChampion != null)
             {
-                healthGain = 75 + (owner.Stats.Level * 15);
-                if (mostWoundedAlliedChampion.HasBuffGameScriptActive("HealCheck", "HealCheck"))
-                {
-                    healthGain *= 0.5f;
-                }
-                newHealth = mostWoundedAlliedChampion.Stats.CurrentHealth + healthGain;
-                maxHealth = mostWoundedAlliedChampion.Stats.HealthPoints.Total;
-                mostWoundedAlliedChampion.Stats.CurrentHealth = Math.Min(maxHealth, newHealth);
-                mostWoundedAlliedChampion.AddBuffGameScript("HealSpeed", "HealSpeed", spell, 1.0f, true);
-                mostWoundedAlliedChampion.AddBuffGameScript("HealCheck", "HealCheck", spell, 35.0f, true);
-                ApiFunctionManager.AddParticleTarget(owner, "global_ss_heal_02.troy", mostWoundedAlliedChampion);
-                ApiFunctionManager.AddParticleTarget(owner, "global_ss_heal_speedboost.troy", mostWoundedAlliedChampion);
+                PerformHeal(owner, spell, mostWoundedAlliedChampion);
             }
 
-            healthGain = 75 + (owner.Stats.Level * 15);
-            if (owner.HasBuffGameScriptActive("HealCheck", "HealCheck"))
-            {
-                healthGain *= 0.5f;
-            }
-            newHealth = owner.Stats.CurrentHealth + healthGain;
-            maxHealth = owner.Stats.HealthPoints.Total;
-            owner.Stats.CurrentHealth = Math.Min(maxHealth, newHealth);
-
-            owner.AddBuffGameScript("HealSpeed", "HealSpeed", spell, 1.0f, true);
-            owner.AddBuffGameScript("HealCheck", "HealCheck", spell, 35.0f, true);
-            ApiFunctionManager.AddParticleTarget(owner, "global_ss_heal_02.troy",owner);
-            ApiFunctionManager.AddParticleTarget(owner, "global_ss_heal_speedboost.troy", owner);
+            PerformHeal(owner, spell, owner);
         }
 
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
+        }
+
+        private void PerformHeal(Champion owner, Spell spell, Champion target)
+        {
+            float healthGain = 75 + (target.Stats.Level * 15);
+            if (target.HasBuffGameScriptActive("HealCheck", "HealCheck"))
+            {
+                healthGain *= 0.5f;
+            }
+            var newHealth = target.Stats.CurrentHealth + healthGain;
+            target.Stats.CurrentHealth = Math.Min(newHealth, target.Stats.HealthPoints.Total);
+            target.AddBuffGameScript("HealSpeed", "HealSpeed", spell, 1.0f, true);
+            target.AddBuffGameScript("HealCheck", "HealCheck", spell, 35.0f, true);
+            ApiFunctionManager.AddParticleTarget(owner, "global_ss_heal_02.troy", target);
+            ApiFunctionManager.AddParticleTarget(owner, "global_ss_heal_speedboost.troy", target);
         }
 
         public void OnUpdate(double diff)

--- a/Champions/Global/SummonerHeal.cs
+++ b/Champions/Global/SummonerHeal.cs
@@ -18,14 +18,14 @@ namespace Spells
         public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
         {
             var units = ApiFunctionManager.GetChampionsInRange(owner, 850, true);
+            units.Remove(owner);
             Champion mostWoundedAlliedChampion = null;
             float lowestHealthPercentage = 100;
             float maxHealth;
             float newHealth;
-            for (var i = 0; i <= units.Count - 1; i++)
-            {
-                var value = units[i];
-                if (owner.Team == value.Team && i != 0)
+            float healthGain;
+            foreach(var value in units) {
+                if (owner.Team == value.Team)
                 {
                     var currentHealth = value.Stats.CurrentHealth;
                     maxHealth = value.Stats.HealthPoints.Total;
@@ -39,41 +39,32 @@ namespace Spells
 
             if (mostWoundedAlliedChampion != null)
             {
-                newHealth = mostWoundedAlliedChampion.Stats.CurrentHealth + 75 + owner.Stats.Level * 15;
+                healthGain = 75 + (owner.Stats.Level * 15);
+                if (mostWoundedAlliedChampion.HasBuffGameScriptActive("HealCheck", "HealCheck"))
+                {
+                    healthGain *= 0.5f;
+                }
+                newHealth = mostWoundedAlliedChampion.Stats.CurrentHealth + healthGain;
                 maxHealth = mostWoundedAlliedChampion.Stats.HealthPoints.Total;
                 mostWoundedAlliedChampion.Stats.CurrentHealth = Math.Min(maxHealth, newHealth);
-
-                ApiFunctionManager.AddBuffHudVisual("SummonerHeal", 1.0f, 1, mostWoundedAlliedChampion, 1.0f);
-                var statMod2 = new StatsModifier
-                {
-                    MoveSpeed =
-                    {
-                        PercentBonus = 0.3f
-                    }
-                };
-                mostWoundedAlliedChampion.AddStatModifier(statMod2);
-                ApiFunctionManager.CreateTimer(1.0f, () => { mostWoundedAlliedChampion.RemoveStatModifier(statMod2); });
-                ApiFunctionManager.AddParticleTarget(mostWoundedAlliedChampion, "global_ss_heal_02.troy",
-                    mostWoundedAlliedChampion);
-                ApiFunctionManager.AddParticleTarget(mostWoundedAlliedChampion, "global_ss_heal_speedboost.troy",
-                    mostWoundedAlliedChampion);
+                mostWoundedAlliedChampion.AddBuffGameScript("HealSpeed", "HealSpeed", spell, 1.0f, true);
+                mostWoundedAlliedChampion.AddBuffGameScript("HealCheck", "HealCheck", spell, 35.0f, true);
+                ApiFunctionManager.AddParticleTarget(owner, "global_ss_heal_02.troy", mostWoundedAlliedChampion);
+                ApiFunctionManager.AddParticleTarget(owner, "global_ss_heal_speedboost.troy", mostWoundedAlliedChampion);
             }
 
-            newHealth = owner.Stats.CurrentHealth + 75 + owner.Stats.Level * 15;
+            healthGain = 75 + (owner.Stats.Level * 15);
+            if (owner.HasBuffGameScriptActive("HealCheck", "HealCheck"))
+            {
+                healthGain *= 0.5f;
+            }
+            newHealth = owner.Stats.CurrentHealth + healthGain;
             maxHealth = owner.Stats.HealthPoints.Total;
             owner.Stats.CurrentHealth = Math.Min(maxHealth, newHealth);
 
-            ApiFunctionManager.AddBuffHudVisual("SummonerHeal", 1.0f, 1, owner, 1.0f);
-            var statMod = new StatsModifier
-            {
-                MoveSpeed =
-                {
-                    PercentBonus = 0.3f
-                }
-            };
-            owner.AddStatModifier(statMod);
-            ApiFunctionManager.CreateTimer(1.0f, () => { owner.RemoveStatModifier(statMod); });
-            ApiFunctionManager.AddParticleTarget(owner, "global_ss_heal.troy", owner);
+            owner.AddBuffGameScript("HealSpeed", "HealSpeed", spell, 1.0f, true);
+            owner.AddBuffGameScript("HealCheck", "HealCheck", spell, 35.0f, true);
+            ApiFunctionManager.AddParticleTarget(owner, "global_ss_heal_02.troy",owner);
             ApiFunctionManager.AddParticleTarget(owner, "global_ss_heal_speedboost.troy", owner);
         }
 


### PR DESCRIPTION
Summoner: Heal was not applying a debuff that prevented its use from being chained multiple times. Additionally, its movement speed was not attatched to a buff, allowing it to stack short bursts of movement speed when casts were spammed. (Note that particles are still added outside of Heal's buff; this is to be fixed in a later update when a Particle's source is not required to be a champion)