### PR TITLE
Damage struct now used. Ezreal + Garen updates.

### DIFF
--- a/Buffs/EzrealEssenceFluxBuff/EzrealEssenceFluxBuff.cs
+++ b/Buffs/EzrealEssenceFluxBuff/EzrealEssenceFluxBuff.cs
@@ -1,0 +1,35 @@
+﻿using GameServerCore.Enums;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+using LeagueSandbox.GameServer.GameObjects.Spells;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+
+namespace EzrealEssenceFluxBuff
+{
+    internal class EzrealEssenceFluxBuff : IBuffGameScript
+    {
+        private Buff _healBuff;
+        private StatsModifier _statMod;
+
+        public void OnActivate(ObjAiBase unit, Spell ownerSpell)
+        {
+            _statMod = new StatsModifier();
+            _statMod.AttackSpeed.PercentBonus = _statMod.AttackSpeed.PercentBonus 
+                + (0.05f * ownerSpell.Level) + 0.15f;
+            unit.AddStatModifier(_statMod);
+            _healBuff = AddBuffHudVisual("EzrealEssenceFluxBuff", 35.0f, 1, BuffType.COMBAT_ENCHANCER, unit);
+        }
+
+        public void OnDeactivate(ObjAiBase unit)
+        {
+            unit.RemoveStatModifier(_statMod);
+            RemoveBuffHudVisual(_healBuff);
+        }
+
+        public void OnUpdate(double diff)
+        {
+
+        }
+    }
+}

--- a/Champions/Akali/E.cs
+++ b/Champions/Akali/E.cs
@@ -28,16 +28,12 @@ namespace Spells
         {
             var ap = owner.Stats.AbilityPower.Total * 0.3f;
             var ad = owner.Stats.AttackDamage.Total * 0.6f;
-            var damage = 40 + spell.Level * 30 + ap + ad;
+            var damage = new Damage(40 + spell.Level * 30 + ap + ad, 
+                DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
             foreach (var enemyTarget in GetUnitsInRange(owner, 300, true)
                 .Where(x => x.Team == CustomConvert.GetEnemyTeam(owner.Team)))
             {
-                enemyTarget.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL,
-                    false);
-                if (target.IsDead)
-                {
-                    spell.LowerCooldown(2, spell.CurrentCooldown * 0.6f);
-                }
+                enemyTarget.TakeDamage(owner, damage);
             }
         }
 

--- a/Champions/Akali/Q.cs
+++ b/Champions/Akali/Q.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -25,19 +26,16 @@ namespace Spells
 
         public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
         {
-            var current = new Vector2(owner.X, owner.Y);
-            var to = Vector2.Normalize(new Vector2(target.X, target.Y) - current);
-            var range = to * 1150;
-            var trueCoords = current + range;
-            spell.AddProjectile("AkaliMota", trueCoords.X, trueCoords.Y);
+            spell.AddProjectileTarget("AkaliMota", target);
         }
 
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
             var ap = owner.Stats.AbilityPower.Total * 0.4f;
-            var damage = 15 + spell.Level * 20 + ap;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
-            AddParticleTarget(owner, "akali_markOftheAssasin_marker_tar_02.troy", target, 1, "");
+            var damage = new Damage(15 + spell.Level * 20 + ap, DamageType.DAMAGE_TYPE_PHYSICAL, 
+            DamageSource.DAMAGE_SOURCE_ATTACK, false);
+            target.TakeDamage(owner, damage);
+            AddParticleTarget(owner, "akali_markOftheAssasin_marker_tar_02.troy", target);
             projectile.SetToRemove();
         }
 

--- a/Champions/Akali/R.cs
+++ b/Champions/Akali/R.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -32,7 +33,7 @@ namespace Spells
             var trueCoords = current + range;
 
             //TODO: Dash to the correct location (in front of the enemy champion) instead of far behind or inside them
-            DashToLocation(owner, trueCoords.X, trueCoords.Y, 2200, false, "Attack1");
+            DashToUnit(owner, target, 2200, false, "Attack1");
             AddParticleTarget(owner, "akali_shadowDance_tar.troy", target, 1, "");
         }
 
@@ -40,9 +41,9 @@ namespace Spells
         {
             var bonusAd = owner.Stats.AttackDamage.Total - owner.Stats.AttackDamage.BaseValue;
             var ap = owner.Stats.AbilityPower.Total * 0.9f;
-            var damage = 200 + spell.Level * 150 + bonusAd + ap;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL,
+            var damage = new Damage(200 + spell.Level * 150 + bonusAd + ap, DamageType.DAMAGE_TYPE_MAGICAL,
                 DamageSource.DAMAGE_SOURCE_SPELL, false);
+            target.TakeDamage(owner, damage);
         }
 
         public void OnUpdate(double diff)

--- a/Champions/Annie/Q.cs
+++ b/Champions/Annie/Q.cs
@@ -1,3 +1,4 @@
+using GameServerCore;
 using GameServerCore.Enums;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
@@ -29,11 +30,11 @@ namespace Spells
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
             var ap = owner.Stats.AbilityPower.Total * 0.8f;
-            var damage = 45 + spell.Level * 35 + ap;
+            var damage = new Damage(45 + spell.Level * 35 + ap, DamageType.DAMAGE_TYPE_MAGICAL, 
+                DamageSource.DAMAGE_SOURCE_SPELL, false);
             if (target != null && !target.IsDead)
             {
-                target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL,
-                    false);
+                target.TakeDamage(owner, damage);
                 if (target.IsDead)
                 {
                     spell.LowerCooldown(0, spell.GetCooldown());

--- a/Champions/Annie/W.cs
+++ b/Champions/Annie/W.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
+using GameServerCore;
 
 namespace Spells
 {
@@ -40,9 +41,10 @@ namespace Spells
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
             var ap = owner.Stats.AbilityPower.Total * 0.8f;
-            var damage = 70 + spell.Level * 45 + ap;
+            var damage = new Damage(70 + spell.Level * 45 + ap, DamageType.DAMAGE_TYPE_MAGICAL, 
+                DamageSource.DAMAGE_SOURCE_SPELL, false);
 
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            target.TakeDamage(owner, damage);
 
         }
 

--- a/Champions/Blitzcrank/Q.cs
+++ b/Champions/Blitzcrank/Q.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -36,8 +37,9 @@ namespace Spells
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
             var ap = owner.Stats.AbilityPower.Total;
-            var damage = 25 + spell.Level * 55 + ap;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            var damage = new Damage(25 + spell.Level * 55 + ap, DamageType.DAMAGE_TYPE_MAGICAL, 
+                DamageSource.DAMAGE_SOURCE_SPELL, false);
+            target.TakeDamage(owner, damage);
             if (!target.IsDead)
             {
                 AddParticleTarget(owner, "Blitzcrank_Grapplin_tar.troy", target, 1, "L_HAND");

--- a/Champions/Caitlyn/E.cs
+++ b/Champions/Caitlyn/E.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -46,8 +47,9 @@ namespace Spells
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
             var ap = owner.Stats.AbilityPower.Total * 0.8f;
-            var damage = 80 + (spell.Level - 1) * 50 + ap;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            var damage = new Damage(80 + (spell.Level - 1) * 50 + ap, DamageType.DAMAGE_TYPE_MAGICAL, 
+                DamageSource.DAMAGE_SOURCE_SPELL, false);
+            target.TakeDamage(owner, damage);
             var slowDuration = new[] {0, 1, 1.25f, 1.5f, 1.75f, 2}[spell.Level];
             AddBuff("Slow", slowDuration, 1, BuffType.SLOW, (ObjAiBase) target, owner);
             AddParticleTarget(owner, "caitlyn_entrapment_tar.troy", target);

--- a/Champions/Caitlyn/Q.cs
+++ b/Champions/Caitlyn/Q.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+using GameServerCore;
 using GameServerCore.Enums;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
@@ -37,8 +38,9 @@ namespace Spells
             var reduc = Math.Min(projectile.ObjectsHit.Count, 5);
             var baseDamage = new[] {20, 60, 100, 140, 180}[spell.Level - 1] +
                              1.3f * owner.Stats.AttackDamage.Total;
-            var damage = baseDamage * (1 - reduc / 10);
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            var damage = new Damage(baseDamage * (1 - reduc / 10), DamageType.DAMAGE_TYPE_PHYSICAL, 
+                DamageSource.DAMAGE_SOURCE_SPELL, false);
+            target.TakeDamage(owner, damage);
         }
 
         public void OnUpdate(double diff)

--- a/Champions/Caitlyn/R.cs
+++ b/Champions/Caitlyn/R.cs
@@ -1,3 +1,4 @@
+using GameServerCore;
 using GameServerCore.Enums;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
@@ -31,9 +32,10 @@ namespace Spells
             if (target != null && !target.IsDead)
             {
                 // 250/475/700
-                var damage = 250 + owner.Stats.AttackDamage.Total * 2;
-                target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL,
-                    false);
+                var bonusAD = owner.Stats.AttackDamage.Total - owner.Stats.AttackDamage.BaseValue;
+                var damage = new Damage(25 + (225 * spell.Level) + (bonusAD * 2), DamageType.DAMAGE_TYPE_PHYSICAL, 
+                DamageSource.DAMAGE_SOURCE_SPELL, false);
+                target.TakeDamage(owner, damage);
             }
 
             projectile.SetToRemove();

--- a/Champions/Ezreal/E.cs
+++ b/Champions/Ezreal/E.cs
@@ -8,6 +8,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -72,8 +73,9 @@ namespace Spells
 
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
-            target.TakeDamage(owner, 25f + spell.Level * 50f + owner.Stats.AbilityPower.Total * 0.75f,
+            Damage damage = new Damage(25f + spell.Level * 50f + owner.Stats.AbilityPower.Total * 0.75f,
                 DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            target.TakeDamage(owner, damage);
             projectile.SetToRemove();
         }
 

--- a/Champions/Ezreal/Q.cs
+++ b/Champions/Ezreal/Q.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -37,8 +38,9 @@ namespace Spells
         {
             var ad = owner.Stats.AttackDamage.Total * 1.1f;
             var ap = owner.Stats.AbilityPower.Total * 0.4f;
-            var damage = 15 + spell.Level * 20 + ad + ap;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
+            var damage = new Damage(15 + spell.Level * 20 + ad + ap, DamageType.DAMAGE_TYPE_PHYSICAL, 
+                DamageSource.DAMAGE_SOURCE_ATTACK, false);
+            target.TakeDamage(owner, damage);
             for (byte i = 0; i < 4; i++)
             {
                 spell.LowerCooldown(i, 1);

--- a/Champions/Ezreal/R.cs
+++ b/Champions/Ezreal/R.cs
@@ -7,6 +7,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -40,9 +41,9 @@ namespace Spells
             var reduc = Math.Min(projectile.ObjectsHit.Count, 7);
             var bonusAd = owner.Stats.AttackDamage.Total - owner.Stats.AttackDamage.BaseValue;
             var ap = owner.Stats.AbilityPower.Total * 0.9f;
-            var damage = 200 + spell.Level * 150 + bonusAd + ap;
-            target.TakeDamage(owner, damage * (1 - reduc / 10), DamageType.DAMAGE_TYPE_MAGICAL,
-                DamageSource.DAMAGE_SOURCE_SPELL, false);
+            var damage = new Damage((200 + spell.Level * 150 + bonusAd + ap) * (1 - reduc / 10), 
+                DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            target.TakeDamage(owner, damage);
         }
 
         public void OnUpdate(double diff)

--- a/Champions/Ezreal/W.cs
+++ b/Champions/Ezreal/W.cs
@@ -5,6 +5,9 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -34,6 +37,21 @@ namespace Spells
 
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
+            IChampion champion = target as IChampion;
+            if (champion != null)
+            {
+                if (owner.Team != champion.Team)
+                {
+                    var damage = new Damage(25 + (spell.Level * 45) + (owner.Stats.AbilityPower.Total * 0.8f),
+                        DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+                    champion.TakeDamage(owner, damage);
+                }
+                else
+                {
+                    champion.AddBuffGameScript("EzrealEssenceFluxBuff", "EzrealEssenceFluxBuff", spell,
+                        5.0f, true);
+                }
+            }
         }
 
         public void OnUpdate(double diff)

--- a/Champions/Gangplank/Q.cs
+++ b/Champions/Gangplank/Q.cs
@@ -1,4 +1,5 @@
 using System;
+using GameServerCore;
 using GameServerCore.Enums;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
@@ -29,14 +30,14 @@ namespace Spells
 
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
-            var isCrit = new Random().Next(0, 100) < owner.Stats.CriticalChance.Total;
+            var isCrit = new Random().Next(0, 100) < (owner.Stats.CriticalChance.Total * 100);
             var baseDamage = new[] {20, 45, 70, 95, 120}[spell.Level - 1] + owner.Stats.AttackDamage.Total;
-            var damage = isCrit ? baseDamage * owner.Stats.CriticalDamage.Total / 100 : baseDamage;
+            var damage = new Damage(isCrit ? baseDamage * owner.Stats.CriticalDamage.Total / 100 : baseDamage,
+                DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, isCrit);
             var goldIncome = new[] {4, 5, 6, 7, 8}[spell.Level - 1];
             if (target != null && !target.IsDead)
             {
-                target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK,
-                    false);
+                target.TakeDamage(owner, damage);
                 if (target.IsDead)
                 {
                     owner.Stats.Gold += goldIncome;

--- a/Champions/Global/DeathfireGrasp.cs
+++ b/Champions/Global/DeathfireGrasp.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using GameServerCore.Enums;
+using GameServerCore;
 
 namespace Spells
 {
@@ -30,8 +31,9 @@ namespace Spells
 
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
-            var damage = target.Stats.HealthPoints.Total * 0.15f;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL, false);
+            var damage = new Damage(target.Stats.HealthPoints.Total * 0.15f, DamageType.DAMAGE_TYPE_MAGICAL, 
+                DamageSource.DAMAGE_SOURCE_SPELL, false);
+            target.TakeDamage(owner, damage);
             projectile.SetToRemove();
         }
 

--- a/Champions/Global/SummonerDot.cs
+++ b/Champions/Global/SummonerDot.cs
@@ -5,6 +5,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -14,14 +15,14 @@ namespace Spells
         {
             var visualBuff = AddBuffHudVisual("SummonerDot", 4.0f, 1, BuffType.COMBAT_DEHANCER, (ObjAiBase) target, 4.0f);
             var p = AddParticleTarget(owner, "Global_SS_Ignite.troy", target, 1);
-            var damage = 10 + owner.Stats.Level * 4;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            var damage = new Damage(10 + owner.Stats.Level * 4, DamageType.DAMAGE_TYPE_TRUE, 
+                DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL, false);
+            target.TakeDamage(owner, damage);
             for(float i = 1.0f; i < 5; ++i)
             {
                 CreateTimer(1.0f * i, () =>
                 {
-                    target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SPELL,
-                        false);
+                    target.TakeDamage(owner, damage);
                 });
             }
             CreateTimer(4.0f, () =>

--- a/Champions/Global/SummonerSmite.cs
+++ b/Champions/Global/SummonerSmite.cs
@@ -1,3 +1,4 @@
+using GameServerCore;
 using GameServerCore.Enums;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
@@ -13,9 +14,11 @@ namespace Spells
         public void OnStartCasting(Champion owner, Spell spell, AttackableUnit target)
         {
             AddParticleTarget(owner, "Global_SS_Smite.troy", target, 1);
-            var damage = new float[] {390, 410, 430, 450, 480, 510, 540, 570, 600, 640, 680, 420,
-                760, 800, 850, 900, 950, 1000}[owner.Stats.Level - 1];
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            var damage = new Damage(new float[] {390, 410, 430, 450, 480, 510, 540, 570, 600,
+                640, 680, 420, 760, 800, 850, 900, 950, 1000}[owner.Stats.Level - 1], DamageType.DAMAGE_TYPE_TRUE,
+                DamageSource.DAMAGE_SOURCE_SPELL, false); // Smite applies spell effects.
+
+            target.TakeDamage(owner, damage);
         }
 
         public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)

--- a/Champions/Karthus/R.cs
+++ b/Champions/Karthus/R.cs
@@ -32,12 +32,12 @@ namespace Spells
         public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
         {
             var ap = owner.Stats.AbilityPower.Total;
-            var damage = 100 + spell.Level * 150 + ap * 0.6f;
+            var damage = new Damage(100 + spell.Level * 150 + ap * 0.6f, DamageType.DAMAGE_TYPE_MAGICAL, 
+                DamageSource.DAMAGE_SOURCE_SPELL, false);
             foreach (var enemyTarget in GetChampionsInRange(owner, 20000, true)
                 .Where(x => x.Team == CustomConvert.GetEnemyTeam(owner.Team)))
             {
-                enemyTarget.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL,
-                    false);
+                enemyTarget.TakeDamage(owner, damage);
             }
         }
 

--- a/Champions/Kassadin/Q.cs
+++ b/Champions/Kassadin/Q.cs
@@ -5,6 +5,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -31,12 +32,12 @@ namespace Spells
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
             var ap = owner.Stats.AbilityPower.Total * 0.7f;
-            var damage = 30 + spell.Level * 50 + ap;
+            var damage = new Damage(30 + spell.Level * 50 + ap, DamageType.DAMAGE_TYPE_MAGICAL, 
+                DamageSource.DAMAGE_SOURCE_SPELL, false);
 
             if (target != null && !target.IsDead)
             {
-                target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL,
-                    false);
+                target.TakeDamage(owner, damage);
                 if (target.IsDead)
                 {
                 }

--- a/Champions/Lucian/Q.cs
+++ b/Champions/Lucian/Q.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -38,9 +39,10 @@ namespace Spells
 
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
-            var damage = owner.Stats.AttackDamage.Total * (0.45f + spell.Level * 0.15f) + (50 + spell.Level * 30);
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL,
+            var damage = new Damage(owner.Stats.AttackDamage.Total * (0.45f + spell.Level * 0.15f) 
+                + (50 + spell.Level * 30), DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL,
                 false);
+            target.TakeDamage(owner, damage);
         }
 
         public void OnUpdate(double diff)

--- a/Champions/Lux/R.cs
+++ b/Champions/Lux/R.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -39,8 +40,9 @@ namespace Spells
 
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
-            target.TakeDamage(owner, 200f + spell.Level * 100f + owner.Stats.AbilityPower.Total * 0.75f,
+            var damage = new Damage(200f + spell.Level * 100f + owner.Stats.AbilityPower.Total * 0.75f,
                 DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            target.TakeDamage(owner, damage);
         }
 
         public void OnUpdate(double diff)

--- a/Champions/Olaf/Q.cs
+++ b/Champions/Olaf/Q.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -48,8 +49,9 @@ namespace Spells
             AddParticleTarget(owner, "olaf_axeThrow_tar.troy", target, 1);
             var ad = owner.Stats.AttackDamage.Total * 1.1f;
             var ap = owner.Stats.AttackDamage.Total * 0.0f;
-            var damage = 15 + spell.Level * 20 + ad + ap;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
+            var damage = new Damage(15 + spell.Level * 20 + ad + ap, DamageType.DAMAGE_TYPE_PHYSICAL, 
+            DamageSource.DAMAGE_SOURCE_ATTACK, false);
+            target.TakeDamage(owner, damage);
         }
 
         public void OnUpdate(double diff)

--- a/Champions/Teemo/Q.cs
+++ b/Champions/Teemo/Q.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Missiles;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore;
 
 namespace Spells
 {
@@ -36,8 +37,9 @@ namespace Spells
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
         {
             var ap = owner.Stats.AbilityPower.Total * 0.8f;
-            var damage = 35 + spell.Level * 45 + ap;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            var damage = new Damage(35 + spell.Level * 45 + ap, DamageType.DAMAGE_TYPE_MAGICAL, 
+            DamageSource.DAMAGE_SOURCE_SPELL, false);
+            target.TakeDamage(owner, damage);
             var time = 1.25f + 0.25f * spell.Level;
             ((ObjAiBase) target).AddBuffGameScript("Blind", "Blind", spell, time);
             AddBuffHudVisual("Blind", time, 1, BuffType.COMBAT_DEHANCER, (ObjAiBase) target, time);

--- a/LeagueSandbox-Default.csproj
+++ b/LeagueSandbox-Default.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="Buffs\Blind\Blind.cs" />
     <Compile Include="Buffs\Disarm\Disarm.cs" />
+    <Compile Include="Buffs\EzrealEssenceFluxBuff\EzrealEssenceFluxBuff.cs" />
     <Compile Include="Buffs\HealCheck\HealCheck.cs" />
     <Compile Include="Buffs\HealSpeed\HealSpeed.cs" />
     <Compile Include="Buffs\Highlander\Highlander.cs" />


### PR DESCRIPTION
Damage Structs are now used for Scripts to handle damage values, rather than them passing the raw values around. Additionally, Ezreal's W, Essence Flux, now functions as more than a projectile, while Garen's E, "Judgment", can now critically strike.

Refs #89 